### PR TITLE
Remove placeholder search bar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { HStack, Input, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { HStack, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import { Button as ChakraButton } from '@chakra-ui/react';
 import { FiChevronDown } from 'react-icons/fi';
 import { Federation, Filter, Sort } from '../federation.types';
@@ -25,7 +25,6 @@ export const Header = (props: HeaderProps): JSX.Element => {
     return (
         <HStack>
             <Button label='Connect Federation' onClick={props.toggleShowConnectFed} />
-            <Input value={searchValue} placeholder='search for item' onChange={handleSearch} />
             <HStack flexDirection='row' alignItems={'center'}>
                 {/* sort menu button */}
                 <Menu>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { HStack, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { Menu, MenuButton, MenuItem, MenuList, Flex, Spacer } from '@chakra-ui/react';
 import { Button as ChakraButton } from '@chakra-ui/react';
 import { FiChevronDown } from 'react-icons/fi';
 import { Federation, Filter, Sort } from '../federation.types';
@@ -23,9 +23,10 @@ export const Header = (props: HeaderProps): JSX.Element => {
     };
 
     return (
-        <HStack>
+        <Flex>
             <Button label='Connect Federation' onClick={props.toggleShowConnectFed} />
-            <HStack flexDirection='row' alignItems={'center'}>
+            <Spacer />
+            <Flex alignItems='center' gap='2'>
                 {/* sort menu button */}
                 <Menu>
                     <MenuButton as={ChakraButton} rightIcon={<FiChevronDown />}>
@@ -48,7 +49,7 @@ export const Header = (props: HeaderProps): JSX.Element => {
                         <MenuItem onClick={() => props.filterCallback(undefined)}>All</MenuItem>
                     </MenuList>
                 </Menu>
-            </HStack>
-        </HStack>
+            </Flex>
+        </Flex>
     );
 };


### PR DESCRIPTION
Removed existing search bar placeholder. We will redevelop this feature at a later time. I then re-stylized the header for responsiveness and usability

---
**before**
![image](https://user-images.githubusercontent.com/11217077/211413365-36190eb8-aebb-4514-b343-8547f76b4d15.png)

**after**
![image](https://user-images.githubusercontent.com/11217077/211413479-a06f59ff-b88e-4fea-b98b-9a27176334b0.png)
