### PR TITLE
Tab control and delight

### DIFF
--- a/src/components/DepositTab.tsx
+++ b/src/components/DepositTab.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react';
-import { Tab, TabPanel, Stack, Card, CardBody, CardFooter, Image, Heading, Text, Spacer, Flex, Link, Progress, Badge } from '@chakra-ui/react'
-import { Button } from '.';
+import { TabPanel, Stack, Card, CardBody, CardFooter, Image, Heading, Text, Spacer, Flex, Link, Progress, Badge } from '@chakra-ui/react'
+import { Button, TabHeader } from '.';
 
-
-interface DepositTabProps {
+export const DepositTabHeader = (): JSX.Element => {
+    return (
+        <TabHeader>
+            Deposit
+        </TabHeader>
+    )
 }
 
 enum DepositStatus {
@@ -12,9 +16,7 @@ enum DepositStatus {
     Complete
 }
 
-export const DepositTabHeader = (): JSX.Element => {
-    return <Tab>Deposit</Tab>
-}
+interface DepositTabProps { }
 
 // TODO: Make API call to get new deposit address
 const getNewDepositAddress = (): string => {

--- a/src/components/FederationCard.tsx
+++ b/src/components/FederationCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Tabs, TabList, TabPanels } from '@chakra-ui/react'
+import { Tabs, TabList, TabPanels, Divider } from '@chakra-ui/react'
 import { Federation } from '../federation.types';
 import { Button, InfoTabHeader, InfoTab, DepositTab, DepositTabHeader } from '.';
 
@@ -8,10 +8,36 @@ interface FederationProps {
     onClick: () => void;
 }
 
+enum OpenTab {
+    Off = -1,
+    InfoTab = 0,
+    DepositTab = 1,
+}
+
 export const FederationCard = (props: FederationProps): JSX.Element => {
     const { mint_pubkey, details } = props.federation;
 
     const [showDetails, setShowDetails] = useState<boolean>(false);
+    const [tab, setOpenTab] = useState<{ open: OpenTab, mru: OpenTab }>({ open: OpenTab.Off, mru: OpenTab.Off });
+
+    const tabControl = (openTab: number) => {
+        setOpenTab({ open: openTab, mru: openTab });
+        setShowDetails(true);
+    };
+
+    const detailsControl = () => {
+        let nextState = !showDetails;
+        if (nextState) {
+            // If we are going to show details and there is no open tab,
+            // start off with the InfoTab, otherwise, open the most recently open tab
+            tab.mru < 0 ?
+                setOpenTab({ open: OpenTab.InfoTab, mru: OpenTab.InfoTab }) :
+                setOpenTab({ open: tab.mru, mru: tab.mru });
+        } else {
+            setOpenTab({ open: OpenTab.Off, mru: tab.mru });
+        }
+        setShowDetails(nextState);
+    };
 
     const getFederationName = (name: string): string => {
         return name.charAt(0).toUpperCase() + name.charAt(1).toUpperCase();
@@ -31,20 +57,24 @@ export const FederationCard = (props: FederationProps): JSX.Element => {
                         </section>
                     </div>
                     <section>
-                        <Button label='details' onClick={() => setShowDetails(!showDetails)} />
+                        <Button label='details' onClick={detailsControl} />
                     </section>
                 </div>
-                {showDetails && <Tabs>
-                    <TabList>
+                <Tabs index={tab.open} onChange={tabControl} pt={3} variant="unstyled">
+                    <TabList gap={2}>
                         <InfoTabHeader />
                         <DepositTabHeader />
                     </TabList>
-
-                    <TabPanels>
-                        <InfoTab {...details} />
-                        <DepositTab {...details} />
-                    </TabPanels>
-                </Tabs>}
+                    {showDetails &&
+                        <>
+                            <Divider />
+                            <TabPanels>
+                                <InfoTab {...details} />
+                                <DepositTab {...details} />
+                            </TabPanels>
+                        </>
+                    }
+                </Tabs>
             </main>
         </>
     );

--- a/src/components/FederationCard.tsx
+++ b/src/components/FederationCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Tabs, TabList, TabPanels, Divider } from '@chakra-ui/react'
+import { Tabs, TabList, TabPanels, Divider, Collapse } from '@chakra-ui/react'
 import { Federation } from '../federation.types';
 import { Button, InfoTabHeader, InfoTab, DepositTab, DepositTabHeader } from '.';
 
@@ -65,15 +65,13 @@ export const FederationCard = (props: FederationProps): JSX.Element => {
                         <InfoTabHeader />
                         <DepositTabHeader />
                     </TabList>
-                    {showDetails &&
-                        <>
-                            <Divider />
-                            <TabPanels>
-                                <InfoTab {...details} />
-                                <DepositTab {...details} />
-                            </TabPanels>
-                        </>
-                    }
+                    <Collapse in={showDetails} animateOpacity>
+                        <Divider />
+                        <TabPanels>
+                            <InfoTab {...details} />
+                            <DepositTab {...details} />
+                        </TabPanels>
+                    </Collapse>
                 </Tabs>
             </main>
         </>

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -1,16 +1,18 @@
-import React, { useState } from 'react';
-import { Tab, TabPanel } from '@chakra-ui/react'
+import React from 'react';
+import { TabPanel } from '@chakra-ui/react'
+import { TabHeader } from '.';
 
-interface InfoTabHeaderProps {
+export const InfoTabHeader = (): JSX.Element => {
+    return (
+        <TabHeader>
+            Info
+        </TabHeader>
+    )
 }
 
 interface InfoTabProps {
     date_created: string;
     description: string;
-}
-
-export const InfoTabHeader = (props: InfoTabHeaderProps): JSX.Element => {
-    return <Tab>Info</Tab>
 }
 
 export const InfoTab = React.memo((props: InfoTabProps): JSX.Element => {

--- a/src/components/TabHeader.tsx
+++ b/src/components/TabHeader.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Button, useTab, useMultiStyleConfig } from '@chakra-ui/react'
+
+interface TabHeaderProps {
+    children?: React.ReactNode;
+}
+
+export const TabHeader = React.forwardRef((
+    props: TabHeaderProps,
+    ref?: React.Ref<HTMLElement> | undefined
+): JSX.Element => {
+    const tabProps = useTab({ ...props, ref })
+    const styles = useMultiStyleConfig('Tabs', tabProps)
+
+    return (
+        <Button __css={styles.tab} {...tabProps}>
+            {tabProps.children}
+        </Button>
+    )
+});

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -3,5 +3,6 @@ export { FederationCard } from './FederationCard';
 export { Header } from './Header'
 export { Input } from './Input';
 export { ConnectFederation } from './ConnectFederation';
+export { TabHeader } from './TabHeader';
 export { InfoTab, InfoTabHeader } from './InfoTab';
 export { DepositTab, DepositTabHeader } from './DepositTab';


### PR DESCRIPTION
Improve the Federation card tab experience in the following ways:
- Always visible tab headers. These are useful for single click entry into action tabs
![image](https://user-images.githubusercontent.com/11217077/211658819-8dede1e1-3019-415b-8a98-74ea43e128c9.png)
  - TODO: The headers should indicate actionability. Maybe use button UI indicators?
- Details button opens / hides the action tabs
  - This works with MRU recall of the last open tab
  - This opens the Info tab if there's no MRU tab in the current session
 See [deployment preview]()