### PR TITLE
Connect Lightning experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@types/valid-url": "^1.0.3",
     "framer-motion": "^6",
     "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
@@ -20,6 +21,7 @@
     "react-icons": "^4.7.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
+    "valid-url": "^1.0.9",
     "web-vitals": "^2.1.0"
   },
   "scripts": {

--- a/src/Admin.tsx
+++ b/src/Admin.tsx
@@ -11,7 +11,7 @@ import { data } from './federation.data';
 
 export const Admin = React.memo(() => {
     const [fedlist, setFedlist] = useState<Federation[]>(data.federations);
-    const [isLnConnected] = useState<boolean>(false);
+    const [isLnConnected, updateIsLnConnected] = useState<boolean>(false);
 
     const [ showConnectLn, toggleShowConnectLn ] = useState<boolean>(true);
     const [ showConnectFed, toggleShowConnectFed ] = useState<boolean>(false);
@@ -51,6 +51,13 @@ export const Admin = React.memo(() => {
         }
     };
 
+    // TODO: Make real api call to connect gateway to proposed lightning rpc service
+    const proposeGatewayLightningService = async (url: URL) => {
+        console.log(url);
+        updateIsLnConnected(true);
+        toggleShowConnectLn(false);
+    };
+
     return (
         <Box m='10'>
             <Header
@@ -61,7 +68,7 @@ export const Admin = React.memo(() => {
                 filterCallback={filterFederations}
                 sortCallback={sortFederations}
             />
-            <ConnectLightning isOpen={showConnectLn} />
+            <ConnectLightning isOpen={showConnectLn} proposeGatewayLightningService={proposeGatewayLightningService} />
             <ConnectFederation isOpen={showConnectFed} />
             <Stack spacing={6} pt={6}>
                 {fedlist.map((federation: Federation) => {

--- a/src/Admin.tsx
+++ b/src/Admin.tsx
@@ -1,12 +1,20 @@
 import React, { useState } from 'react';
-import { Header, FederationCard, ConnectFederation } from './components';
+import { Box, Stack } from '@chakra-ui/react';
+import {
+    Header,
+    FederationCard,
+    ConnectFederation,
+    ConnectLightning,
+} from './components';
 import { Federation, Filter, Sort } from './federation.types';
 import { data } from './federation.data';
-import { Box, Stack, useDisclosure } from '@chakra-ui/react';
 
 export const Admin = React.memo(() => {
     const [fedlist, setFedlist] = useState<Federation[]>(data.federations);
-    const { isOpen: showConnectFed, onToggle: toggleShowConnectFed } = useDisclosure();
+    const [isLnConnected] = useState<boolean>(false);
+
+    const [ showConnectLn, toggleShowConnectLn ] = useState<boolean>(true);
+    const [ showConnectFed, toggleShowConnectFed ] = useState<boolean>(false);
 
     const filterFederations = (filter: Filter) => {
         let federations = filter === undefined ? data.federations : data.federations.filter((federation) => federation.details.active === filter);
@@ -46,11 +54,14 @@ export const Admin = React.memo(() => {
     return (
         <Box m='10'>
             <Header
-                toggleShowConnectFed={toggleShowConnectFed}
                 data={data.federations}
+                isLnConnected={isLnConnected}
+                toggleShowConnectLn={() => toggleShowConnectLn(!showConnectLn)}
+                toggleShowConnectFed={() => toggleShowConnectFed(!showConnectFed)}
                 filterCallback={filterFederations}
                 sortCallback={sortFederations}
             />
+            <ConnectLightning isOpen={showConnectLn} />
             <ConnectFederation isOpen={showConnectFed} />
             <Stack spacing={6} pt={6}>
                 {fedlist.map((federation: Federation) => {

--- a/src/Admin.tsx
+++ b/src/Admin.tsx
@@ -68,7 +68,7 @@ export const Admin = React.memo(() => {
                 filterCallback={filterFederations}
                 sortCallback={sortFederations}
             />
-            <ConnectLightning isOpen={showConnectLn} proposeGatewayLightningService={proposeGatewayLightningService} />
+            <ConnectLightning isOpen={showConnectLn} isLnConnected={isLnConnected} proposeGatewayLightningService={proposeGatewayLightningService} />
             <ConnectFederation isOpen={showConnectFed} />
             <Stack spacing={6} pt={6}>
                 {fedlist.map((federation: Federation) => {

--- a/src/components/ConnectLightning.tsx
+++ b/src/components/ConnectLightning.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import { Box, Collapse, HStack } from "@chakra-ui/react";
+import { Button, Input } from ".";
+
+export type ConnectLightningButtonProps = {
+  onClick: () => void;
+};
+
+export const ConnectLightningButton = (props: ConnectLightningButtonProps) => {
+  return <Button label="Connect Lightning" onClick={props.onClick} />;
+};
+
+export type ConnectLightningProps = {
+  isOpen: boolean;
+};
+
+export const ConnectLightning = (props: ConnectLightningProps) => {
+  const [inputString, setInputString] = useState<string>("");
+
+  const handleInputString = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    const { value } = event.target;
+    // TODO: Validate value and show status
+    setInputString(value);
+  };
+
+  return (
+    <Collapse in={props.isOpen} animateOpacity>
+      <Box m="1">
+        <HStack
+          borderRadius="4"
+          p="8"
+          boxShadow="rgba(0, 0, 0, 0.02) 0px 1px 3px 0px, rgba(27, 31, 35, 0.15) 0px 0px 0px 1px"
+          mt="8"
+          mb="4"
+          spacing="4"
+          alignItems="flex-end"
+        >
+          <Input
+            labelName="Connect Lightning:"
+            placeHolder="Enter url to Gateway lightning service"
+            value={inputString}
+            onChange={(event) => handleInputString(event)}
+          />
+          <Button
+            label="Connect 🚀"
+            borderRadius="4"
+            onClick={() => console.log("clicked")}
+            height="48px"
+            disabled={true}
+          />
+        </HStack>
+      </Box>
+    </Collapse>
+  );
+};

--- a/src/components/ConnectLightning.tsx
+++ b/src/components/ConnectLightning.tsx
@@ -4,15 +4,17 @@ import { isWebUri } from "valid-url";
 import { Button, Input } from ".";
 
 export type ConnectLightningButtonProps = {
+  isLnConnected: boolean;
   onClick: () => void;
 };
 
 export const ConnectLightningButton = (props: ConnectLightningButtonProps) => {
-  return <Button label="Connect Lightning" onClick={props.onClick} />;
+  return <Button label={`${props.isLnConnected ? "Replace" : "Connect"} Lightning`} onClick={props.onClick} />;
 };
 
 export type ConnectLightningProps = {
   isOpen: boolean;
+  isLnConnected: boolean;
   proposeGatewayLightningService: (url: URL) => Promise<void>;
 };
 
@@ -64,7 +66,7 @@ export const ConnectLightning = (props: ConnectLightningProps) => {
           alignItems="flex-end"
         >
           <Input
-            labelName="Connect Lightning:"
+            labelName={`${props.isLnConnected ? "Replace" : "Connect"} Lightning:`}
             placeHolder="Enter url to Gateway lightning service"
             value={url.value}
             onChange={(event) => handleInputString(event)}

--- a/src/components/ConnectLightning.tsx
+++ b/src/components/ConnectLightning.tsx
@@ -13,6 +13,7 @@ export const ConnectLightningButton = (props: ConnectLightningButtonProps) => {
 
 export type ConnectLightningProps = {
   isOpen: boolean;
+  proposeGatewayLightningService: (url: URL) => Promise<void>;
 };
 
 interface LnrpcURL {
@@ -33,6 +34,21 @@ export const ConnectLightning = (props: ConnectLightningProps) => {
     } else {
       updateUrl({ value: validatedValue, isValid: true });
     }
+  };
+
+  const connectLightning = () => {
+    props
+      .proposeGatewayLightningService(new URL(url.value))
+      .then(() => {
+        // show success ui
+      })
+      .catch((e: any) => {
+        // show error ui
+        console.error(e);
+      })
+      .finally(() => {
+        updateUrl({ value: "", isValid: false });
+      });
   };
 
   return (
@@ -56,7 +72,7 @@ export const ConnectLightning = (props: ConnectLightningProps) => {
           <Button
             label="Connect 🚀"
             borderRadius="4"
-            onClick={() => console.log("clicked")}
+            onClick={connectLightning}
             height="48px"
             disabled={!url.isValid}
           />

--- a/src/components/ConnectLightning.tsx
+++ b/src/components/ConnectLightning.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Box, Collapse, HStack } from "@chakra-ui/react";
+import { isWebUri } from "valid-url";
 import { Button, Input } from ".";
 
 export type ConnectLightningButtonProps = {
@@ -14,14 +15,24 @@ export type ConnectLightningProps = {
   isOpen: boolean;
 };
 
+interface LnrpcURL {
+  value: string;
+  isValid: boolean;
+}
+
 export const ConnectLightning = (props: ConnectLightningProps) => {
-  const [inputString, setInputString] = useState<string>("");
+  const [url, updateUrl] = useState<LnrpcURL>({ value: "", isValid: false });
 
   const handleInputString = (event: React.ChangeEvent<HTMLInputElement>) => {
     event.preventDefault();
+
     const { value } = event.target;
-    // TODO: Validate value and show status
-    setInputString(value);
+    let validatedValue = isWebUri(value);
+    if (validatedValue === undefined) {
+      updateUrl({ value, isValid: false });
+    } else {
+      updateUrl({ value: validatedValue, isValid: true });
+    }
   };
 
   return (
@@ -39,7 +50,7 @@ export const ConnectLightning = (props: ConnectLightningProps) => {
           <Input
             labelName="Connect Lightning:"
             placeHolder="Enter url to Gateway lightning service"
-            value={inputString}
+            value={url.value}
             onChange={(event) => handleInputString(event)}
           />
           <Button
@@ -47,7 +58,7 @@ export const ConnectLightning = (props: ConnectLightningProps) => {
             borderRadius="4"
             onClick={() => console.log("clicked")}
             height="48px"
-            disabled={true}
+            disabled={!url.isValid}
           />
         </HStack>
       </Box>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,7 +18,7 @@ export const Header = (props: HeaderProps): JSX.Element => {
     return (
         <Flex>
             <Flex alignItems='center' gap={2}>
-                <ConnectLightningButton onClick={props.toggleShowConnectLn} />
+                <ConnectLightningButton onClick={props.toggleShowConnectLn} isLnConnected={props.isLnConnected} />
                 <Button label='Connect Federation' onClick={props.toggleShowConnectFed} disabled={!props.isLnConnected} />
             </Flex>
             <Spacer />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,15 +15,6 @@ export type HeaderProps = {
 };
 
 export const Header = (props: HeaderProps): JSX.Element => {
-    const [searchValue, setSearchValue] = useState<string>('');
-
-    const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
-        event.preventDefault();
-        const { value } = event.target;
-        setSearchValue(value);
-        console.log(searchValue);
-    };
-
     return (
         <Flex>
             <Flex alignItems='center' gap={2}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,13 +3,15 @@ import { Menu, MenuButton, MenuItem, MenuList, Flex, Spacer } from '@chakra-ui/r
 import { Button as ChakraButton } from '@chakra-ui/react';
 import { FiChevronDown } from 'react-icons/fi';
 import { Federation, Filter, Sort } from '../federation.types';
-import { Button } from './Button';
+import { Button, ConnectLightningButton } from '.';
 
 export type HeaderProps = {
     data: Federation[];
+    isLnConnected: boolean;
+    toggleShowConnectLn: () => void;
+    toggleShowConnectFed: () => void;
     filterCallback: (filter: Filter) => void;
     sortCallback: (sort: Sort) => void;
-    toggleShowConnectFed: () => void;
 };
 
 export const Header = (props: HeaderProps): JSX.Element => {
@@ -24,7 +26,10 @@ export const Header = (props: HeaderProps): JSX.Element => {
 
     return (
         <Flex>
-            <Button label='Connect Federation' onClick={props.toggleShowConnectFed} />
+            <Flex alignItems='center' gap={2}>
+                <ConnectLightningButton onClick={props.toggleShowConnectLn} />
+                <Button label='Connect Federation' onClick={props.toggleShowConnectFed} disabled={!props.isLnConnected} />
+            </Flex>
             <Spacer />
             <Flex alignItems='center' gap='2'>
                 {/* sort menu button */}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -3,6 +3,7 @@ export { FederationCard } from './FederationCard';
 export { Header } from './Header'
 export { Input } from './Input';
 export { ConnectFederation } from './ConnectFederation';
+export { ConnectLightning, ConnectLightningButton } from './ConnectLightning';
 export { TabHeader } from './TabHeader';
 export { InfoTab, InfoTabHeader } from './InfoTab';
 export { DepositTab, DepositTabHeader } from './DepositTab';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,6 +3086,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
+"@types/valid-url@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.3.tgz#a124389fb953559c7f889795a98620e91adb3687"
+  integrity sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==
+
 "@types/ws@^8.5.1":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
@@ -9888,6 +9893,11 @@ v8-to-istanbul@^8.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
From within Gateway admin dashboard, Admins can update the Lightning RPC service connected to the gateway.
- The admin supplies a url to ConnectLightning experience
- The url is validated and proposed to `gatewayd` instance if valid and confirmed by the admin

> default connect lnrpc on app start: no lnrpc connected
![image](https://user-images.githubusercontent.com/11217077/212644525-65db223e-04cf-466e-ba9a-374f147bfb3f.png)

> valid lnrpc url entered : ready to propose lnrpc to gateway
![image](https://user-images.githubusercontent.com/11217077/212644774-035a333a-555a-425f-966c-94b9f29653ac.png)

> gateway has an active lnrpc, previously proposed and connected:
>  - connect fed is possible
>  - connect lightning experience has UI to indicate that we well be "replacing" existing lnrpc should we connect again
>
![image](https://user-images.githubusercontent.com/11217077/212647558-22372457-4438-40dc-ba78-d1e528840c70.png)


**Note:**
- Connecting a new lightning rpc will overwrite any previous lightning rpc connected: TODO: show this in UI
- A gateway with no connected lightning rpc service is in critically bad state.
  - the admin should be alerted in UI. **Alerts should be of high priority**
  - the admin should not be able to connect new federations
  - the admin should 