### PR TITLE
Validate connect fed

### DIFF
--- a/src/components/ConnectFederation.tsx
+++ b/src/components/ConnectFederation.tsx
@@ -23,8 +23,13 @@ export const ConnectFederation = (connect: ConnectFederationProps) => {
 	};
 
 	const handleConnectFederation = async () => {
-		const federation = await mintgate.connectFederation(connectInfo);
-		connect.renderConnectedFedCallback(federation);
+		try {
+			const federation = await mintgate.connectFederation(connectInfo);
+			connect.renderConnectedFedCallback(federation);
+			// TODO: Show success UI
+		} catch (e: any) {
+			// TODO: Show error UI
+		}
 	};
 
 	return (


### PR DESCRIPTION
Add basic validation to connect fed experience.

Example valid input string: `"{\"members\":[[0,\"ws:\/\/localhost:8174\/\"],[1,\"ws:\/\/localhost:18184\/\"],[2,\"ws:\/\/localhost:18194\/\"],[3,\"ws:\/\/localhost:18204\/\"]]}"`

- Guardian urls withing the connect info are recorded as web sockets in this example.
- Ideally, we should be sure of the connect fed guardian url format and validate these as well.

Partially addresses #30 