### PR TITLE
Remove integration for Connect Lightning experience

### DIFF
--- a/src/Admin.tsx
+++ b/src/Admin.tsx
@@ -4,7 +4,6 @@ import {
 	Header,
 	FederationCard,
 	ConnectFederation,
-	ConnectLightning,
 	ApiContext,
 } from './components';
 import { GatewayInfo, NullGatewayInfo } from './api';
@@ -16,9 +15,7 @@ export const Admin = React.memo(function Admin(): JSX.Element {
 	const [gatewayInfo, setGatewayInfo] = useState<GatewayInfo>(NullGatewayInfo);
 
 	const [fedlist, setFedlist] = useState<Federation[]>([]);
-	const [isLnConnected, updateIsLnConnected] = useState<boolean>(false);
 
-	const [showConnectLn, toggleShowConnectLn] = useState<boolean>(true);
 	const [showConnectFed, toggleShowConnectFed] = useState<boolean>(false);
 
 	useEffect(() => {
@@ -85,13 +82,6 @@ export const Admin = React.memo(function Admin(): JSX.Element {
 		}
 	};
 
-	// TODO: Make real api call to connect gateway to proposed lightning rpc service
-	const proposeGatewayLightningService = async (url: URL) => {
-		console.log(url);
-		updateIsLnConnected(true);
-		toggleShowConnectLn(false);
-	};
-
 	const renderConnectedFedCallback = (federation: Federation) => {
 		setFedlist([federation, ...fedlist]);
 	};
@@ -108,16 +98,9 @@ export const Admin = React.memo(function Admin(): JSX.Element {
 			>
 				<Header
 					data={gatewayInfo.federations}
-					isLnConnected={isLnConnected}
-					toggleShowConnectLn={() => toggleShowConnectLn(!showConnectLn)}
 					toggleShowConnectFed={() => toggleShowConnectFed(!showConnectFed)}
 					filterCallback={filterFederations}
 					sortCallback={sortFederations}
-				/>
-				<ConnectLightning
-					isOpen={showConnectLn}
-					isLnConnected={isLnConnected}
-					proposeGatewayLightningService={proposeGatewayLightningService}
 				/>
 				<ConnectFederation
 					isOpen={showConnectFed}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,13 +15,11 @@ import { Button as ChakraButton } from '@chakra-ui/react';
 import { FiChevronDown } from 'react-icons/fi';
 import { HiMenuAlt3 } from 'react-icons/hi';
 import { Federation, Filter, Sort } from '../federation.types';
-import { Button, ConnectLightningButton } from '.';
+import { Button } from '.';
 import '../index.css';
 
 export type HeaderProps = {
 	data: Federation[];
-	isLnConnected: boolean;
-	toggleShowConnectLn: () => void;
 	toggleShowConnectFed: () => void;
 	filterCallback: (filter: Filter) => void;
 	sortCallback: (sort: Sort) => void;
@@ -33,13 +31,8 @@ export const Header = React.memo(function Header(
 	return (
 		<Flex>
 			<Flex alignItems='center' gap={2}>
-				<ConnectLightningButton
-					onClick={props.toggleShowConnectLn}
-					isLnConnected={props.isLnConnected}
-				/>
 				<Button
 					onClick={props.toggleShowConnectFed}
-					disabled={!props.isLnConnected}
 					fontSize={{ base: '12px', md: '13px', lg: '16px' }}
 					p={{ base: '10px', md: '13px', lg: '16px' }}
 				>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11217077/215608290-f4ff2e8c-2f24-4bdb-a225-b7f6f1e6fb80.png)
Connect Lightning allows hot-swapping of a lightning node to Fedimint federations. Ths experience is not on path for support by `gatewayd`. This pr reverts the ui included as part of mintgate mvp, until we are ready to support it.