### PR TITLE
Explorer API with autodeposit

### DIFF
--- a/src/api/Explorer.ts
+++ b/src/api/Explorer.ts
@@ -65,7 +65,9 @@ export class BlockstreamExplorer implements Explorer {
 					amount_btc: txout.value / 100000000,
 					confirmations: 0,
 					status: 'pending',
-					viewTransactionUrl: `${this.baseUrl}/tx/${tx.txid}`,
+					viewTransactionUrl: `${this.baseUrl.replace('/api/', '/')}tx/${
+						tx.txid
+					}`,
 					transactionOutProof: 'unknown', // fixme
 					transactionHash: 'unknown', // fixme
 				});

--- a/src/api/Explorer.ts
+++ b/src/api/Explorer.ts
@@ -1,9 +1,18 @@
 export interface Explorer {
+	// Try get transaction status for a tx with given address
 	watchAddessForTransaction: (
 		address: string
 	) => Promise<TransactionStatus | null>;
 
-	watchTransactionStatus: (txid: string) => Promise<TransactionStatus>;
+	// Try get transaction status for a tx with given address and transaction id.
+	// Since we know the transaction id, this should be more efficient than watchAddessForTransaction
+	watchTransactionStatus: (
+		address: string,
+		txid: string
+	) => Promise<TransactionStatus>;
+
+	// Try get transaction proof for a tx with given transaction id
+	fetchTransactionProof: (txid: string) => Promise<TransactionProof>;
 }
 
 export interface TransactionStatus {
@@ -17,7 +26,10 @@ export interface TransactionStatus {
 	status: 'pending' | 'confirmed';
 	/** Url to view this transaction on the explorer where status information was sourced */
 	viewTransactionUrl: string;
-	/** Proof of transaction */
+}
+
+export interface TransactionProof {
+	/** Merkle proof of transaction */
 	transactionOutProof: string;
 	/** Sha256 hash of transaction */
 	transactionHash: string;
@@ -68,8 +80,6 @@ export class BlockstreamExplorer implements Explorer {
 					viewTransactionUrl: `${this.baseUrl.replace('/api/', '/')}tx/${
 						tx.txid
 					}`,
-					transactionOutProof: 'unknown', // fixme
-					transactionHash: 'unknown', // fixme
 				});
 			}
 
@@ -80,8 +90,62 @@ export class BlockstreamExplorer implements Explorer {
 	};
 
 	watchTransactionStatus = async (
-		_txid: string
+		address: string,
+		txid: string
 	): Promise<TransactionStatus> => {
-		return Promise.reject('Not implemented');
+		try {
+			const res: Response = await fetch(`${this.baseUrl}/tx/${txid}`);
+
+			if (res.ok) {
+				const tx = await res.json();
+
+				const txout = tx.vout.find((out: any) => {
+					return out.scriptpubkey_address === address;
+				});
+
+				if (!txout) {
+					return Promise.reject('No transaction found to our address');
+				}
+
+				return Promise.resolve({
+					transactionId: tx.txid,
+					amount_btc: txout.value / 100000000,
+					confirmations: 2, // use block height to determing confirmations
+					status: tx.status.confirmed ? 'confirmed' : 'pending',
+					viewTransactionUrl: `${this.baseUrl.replace('/api/', '/')}tx/${
+						tx.txid
+					}`,
+				});
+			}
+
+			throw new Error('Error fetching transaction');
+		} catch (err) {
+			return Promise.reject(err);
+		}
+	};
+
+	fetchTransactionProof = async (txid: string): Promise<TransactionProof> => {
+		try {
+			const proofres: Response = await fetch(
+				`${this.baseUrl}/tx/${txid}/merkleblock-proof`
+			);
+
+			const proof = proofres.ok && (await proofres.json());
+
+			const hashres: Response = await fetch(`${this.baseUrl}/tx/${txid}/hex`);
+
+			const hash = hashres.ok && (await hashres.json());
+
+			if (!proof || !hash) {
+				throw new Error('Error fetching transaction proof');
+			}
+
+			return Promise.resolve({
+				transactionOutProof: proof,
+				transactionHash: hash,
+			});
+		} catch (err) {
+			return Promise.reject(err);
+		}
 	};
 }

--- a/src/api/Explorer.ts
+++ b/src/api/Explorer.ts
@@ -1,0 +1,24 @@
+export interface Explorer {
+	watchAddessForTransaction: (
+		address: string
+	) => Promise<TransactionStatus | null>;
+
+	watchTransactionStatus: (txid: string) => Promise<TransactionStatus>;
+}
+
+export interface TransactionStatus {
+	/** transaction id */
+	transactionId: string;
+	/** amount detected in transaction */
+	amount_btc: number;
+	/** number of confirmations */
+	confirmations: number;
+	/** status of the transaction */
+	status: 'pending' | 'confirmed';
+	/** Url to view this transaction on the explorer where status information was sourced */
+	viewTransactionUrl: string;
+	/** Proof of transaction */
+	transactionOutProof: string;
+	/** Sha256 hash of transaction */
+	transactionHash: string;
+}

--- a/src/api/Explorer.ts
+++ b/src/api/Explorer.ts
@@ -58,7 +58,7 @@ export class BlockstreamExplorer implements Explorer {
 				const txns = await res.json();
 
 				if (txns.length === 0) {
-					return Promise.reject('No transaction found');
+					return Promise.reject('No transaction found in the mempool');
 				}
 
 				let txout: { value: number } | undefined;

--- a/src/api/Explorer.ts
+++ b/src/api/Explorer.ts
@@ -22,3 +22,24 @@ export interface TransactionStatus {
 	/** Sha256 hash of transaction */
 	transactionHash: string;
 }
+
+export class BlockstreamExplorer implements Explorer {
+	// Base url for the blockstream explorer
+	public baseUrl: string;
+
+	constructor(baseUrl: string) {
+		this.baseUrl = baseUrl;
+	}
+
+	watchAddessForTransaction = async (
+		_address: string
+	): Promise<TransactionStatus> => {
+		return Promise.reject('Not implemented');
+	};
+
+	watchTransactionStatus = async (
+		_txid: string
+	): Promise<TransactionStatus> => {
+		return Promise.reject('Not implemented');
+	};
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
 export { type Mintgate, type GatewayInfo, NullGatewayInfo } from './Mintgate';
+export { type Explorer, type TransactionStatus } from './Explorer';
 export { MockMintgate } from './Mintgate.mock';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,7 @@
 export { type Mintgate, type GatewayInfo, NullGatewayInfo } from './Mintgate';
-export { type Explorer, type TransactionStatus } from './Explorer';
 export { MockMintgate } from './Mintgate.mock';
+export {
+	type Explorer,
+	type TransactionStatus,
+	BlockstreamExplorer,
+} from './Explorer';

--- a/src/components/ApiProvider.tsx
+++ b/src/components/ApiProvider.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
-import { Mintgate, MockMintgate } from '../api';
+import { Explorer, BlockstreamExplorer, Mintgate, MockMintgate } from '../api';
 
 interface ApiContextProps {
 	// API to interact with the Gateway server
 	mintgate: Mintgate;
+	explorer: Explorer;
 }
+
+// Using testnet blockstream explorer for all mocks
+const mockExplorer = new BlockstreamExplorer(
+	'https://blockstream.info/testnet/api/'
+);
 
 export const ApiContext = React.createContext<ApiContextProps>({
 	mintgate: new MockMintgate(),
+	explorer: mockExplorer,
 });
 
 export const ApiProvider = React.memo(function ApiProvider({

--- a/src/components/DepositTab.tsx
+++ b/src/components/DepositTab.tsx
@@ -67,9 +67,6 @@ export const DepositTab = React.memo(function DepositTab(): JSX.Element {
 		return () => clearInterval(interval);
 	}, [explorer, address]);
 
-	const mock_txid =
-		'de3d5bf1e3c1b3be2a1e025825f751629390ad60c8f91723e330f2356d99c59b';
-
 	const getDepositCardProps = (): DepositCardProps => {
 		if (txStatus) {
 			return {
@@ -86,8 +83,7 @@ export const DepositTab = React.memo(function DepositTab(): JSX.Element {
 				actions: [
 					{
 						label: 'View Transaction',
-						onClick: () =>
-							window.open(`https://mempool.space/tx/${mock_txid}`, '_blank'),
+						onClick: () => window.open(txStatus.viewTransactionUrl, '_blank'),
 					},
 				],
 				infographic: {

--- a/src/components/DepositTab.tsx
+++ b/src/components/DepositTab.tsx
@@ -253,7 +253,7 @@ const WatchTransaction = ({
 	const [status, setStatus] = useState(txStatus);
 
 	useEffect(() => {
-		const interval = setInterval(async () => {
+		const obseTxSequence = async (timer?: NodeJS.Timer) => {
 			try {
 				const txStatus = await explorer.watchTransactionStatus(
 					address,
@@ -275,7 +275,7 @@ const WatchTransaction = ({
 					);
 
 					console.log('Fedimint Transaction ID: ', fmTxId);
-					clearInterval(interval);
+					timer && clearInterval(timer);
 				}
 
 				setStatus(txStatus);
@@ -283,9 +283,15 @@ const WatchTransaction = ({
 				console.log(e);
 				// TODO: Show error UI
 			}
+		};
+
+		const timer = setInterval(async () => {
+			await obseTxSequence(timer);
 		}, 10000);
 
-		return () => clearInterval(interval);
+		obseTxSequence(timer);
+
+		return () => clearInterval(timer);
 	}, []);
 
 	return (

--- a/src/components/DepositTab.tsx
+++ b/src/components/DepositTab.tsx
@@ -256,17 +256,22 @@ const WatchTransaction = ({
 		const interval = setInterval(async () => {
 			try {
 				const txStatus = await explorer.watchTransactionStatus(
+					address,
 					status.transactionId
 				);
 
 				if (txStatus.confirmations === confirmationsRequired) {
+					const proof = await explorer.fetchTransactionProof(
+						status.transactionId
+					);
+
 					// Automatically complete the deposit to federation
 					// TODO: Call to completeDeposit should be automated.
 					// once all the required data is available, complete the deposit without requiring user interaction.
 					const fmTxId = await mintgate.completeDeposit(
 						federationId,
-						txStatus.transactionId,
-						txStatus.transactionHash
+						proof.transactionOutProof,
+						proof.transactionHash
 					);
 
 					console.log('Fedimint Transaction ID: ', fmTxId);
@@ -278,7 +283,7 @@ const WatchTransaction = ({
 				console.log(e);
 				// TODO: Show error UI
 			}
-		}, 1000);
+		}, 10000);
 
 		return () => clearInterval(interval);
 	}, []);

--- a/src/components/DepositTab.tsx
+++ b/src/components/DepositTab.tsx
@@ -44,8 +44,7 @@ export const DepositTab = React.memo(function DepositTab(): JSX.Element {
 	useEffect(() => {
 		if (!address) return;
 
-		// Watch for a transaction to be sent to the address
-		const interval = setInterval(async () => {
+		const observeMempool = async (timer?: NodeJS.Timer) => {
 			try {
 				const txStatus = await explorer.watchAddessForTransaction(address);
 
@@ -56,15 +55,23 @@ export const DepositTab = React.memo(function DepositTab(): JSX.Element {
 						'Detected a deposit transaction to the address: ',
 						address
 					);
-					clearInterval(interval);
+					timer && clearInterval(timer);
 				}
 			} catch (e) {
 				console.log(e);
 				// TODO: Show error UI
 			}
-		}, 1000);
+		};
 
-		return () => clearInterval(interval);
+		// Watch for a transaction to be sent to the address
+		const timer = setInterval(async () => {
+			await observeMempool(timer);
+		}, 5000);
+
+		// We probably don't need to immediately check mempool for transaction
+		// observeMempool(timer);
+
+		return () => clearInterval(timer);
 	}, [explorer, address]);
 
 	const getDepositCardProps = (): DepositCardProps => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
 import { Admin } from './Admin';
-import { MockMintgate } from './api';
+import { BlockstreamExplorer, MockMintgate } from './api';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 import { ApiProvider } from './components';
@@ -13,6 +13,9 @@ const gateway_api = process.env.REACT_APP_FEDIMINT_GATEWAY_API;
 // TODO: Implement and use real Mintgate API calling into gateway_api server
 const mintgate = gateway_api ? new MockMintgate() : new MockMintgate();
 
+// TODO: Enable configuration to different block explorers
+const explorer = new BlockstreamExplorer('https://blockstream.info/api/');
+
 const root = ReactDOM.createRoot(
 	document.getElementById('root') as HTMLElement
 );
@@ -20,7 +23,7 @@ const root = ReactDOM.createRoot(
 root.render(
 	<React.StrictMode>
 		<ChakraProvider>
-			<ApiProvider props={{ mintgate }}>
+			<ApiProvider props={{ mintgate, explorer }}>
 				<Admin />
 			</ApiProvider>
 		</ChakraProvider>


### PR DESCRIPTION
- Define blockchain explorer api for watching transactions to address, and for watching the status of such transactions
- Autorequest completion of deposit based on #34 once a pending transaction reaches some threshold of confirmations

![image](https://user-images.githubusercontent.com/11217077/217687881-9b5b7038-26f6-42b2-8e89-cda9f3c8ced4.png)

To test out the deposit experience with real funds
1. create a fresh btc address
2. set that as the mock address in [this line](https://github.com/GETLN/mintgate/blob/main/src/api/Mintgate.mock.ts#L54)
3. run the app locally
4. make a small deposit transaction to the address rendered in a deposit tab. **RECKLESS!**
5. watch as the transaction progresses...
- we call [mock complete deposit API](https://github.com/GETLN/mintgate/blob/main/src/api/Mintgate.mock.ts#L82), once the right threshold of confirmations (3) is reached. This is harmless to your funds, ha